### PR TITLE
claude-code-base-action: Construct default Anthropic base URL for Bedrock

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -122,7 +122,7 @@ runs:
         AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
         AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
-        ANTHROPIC_BEDROCK_BASE_URL: ${{ env.ANTHROPIC_BEDROCK_BASE_URL }}
+        ANTHROPIC_BEDROCK_BASE_URL: ${{ env.ANTHROPIC_BEDROCK_BASE_URL || (env.AWS_REGION && format('https://bedrock-runtime.{0}.amazonaws.com', env.AWS_REGION)) }}
 
         # GCP configuration
         ANTHROPIC_VERTEX_PROJECT_ID: ${{ env.ANTHROPIC_VERTEX_PROJECT_ID }}

--- a/test/validate-env.test.ts
+++ b/test/validate-env.test.ts
@@ -63,6 +63,24 @@ describe("validateEnvironmentVariables", () => {
 
       expect(() => validateEnvironmentVariables()).not.toThrow();
     });
+    
+    test("should construct Bedrock base URL from AWS_REGION when ANTHROPIC_BEDROCK_BASE_URL is not provided", () => {
+      // This test verifies our action.yml change, which constructs:
+      // ANTHROPIC_BEDROCK_BASE_URL: ${{ env.ANTHROPIC_BEDROCK_BASE_URL || (env.AWS_REGION && format('https://bedrock-runtime.{0}.amazonaws.com', env.AWS_REGION)) }}
+      
+      process.env.CLAUDE_CODE_USE_BEDROCK = "1";
+      process.env.AWS_REGION = "us-west-2";
+      process.env.AWS_ACCESS_KEY_ID = "test-access-key";
+      process.env.AWS_SECRET_ACCESS_KEY = "test-secret-key";
+      // ANTHROPIC_BEDROCK_BASE_URL is intentionally not set
+      
+      // The actual URL construction happens in the composite action in action.yml
+      // This test is a placeholder to document the behavior
+      expect(() => validateEnvironmentVariables()).not.toThrow();
+      
+      // In the actual action, ANTHROPIC_BEDROCK_BASE_URL would be:
+      // https://bedrock-runtime.us-west-2.amazonaws.com
+    });
 
     test("should fail when AWS_REGION is missing", () => {
       process.env.CLAUDE_CODE_USE_BEDROCK = "1";


### PR DESCRIPTION
# Construct default Anthropic base URL for Bedrock

## Summary
- Automatically constructs the Bedrock API endpoint URL using AWS_REGION when ANTHROPIC_BEDROCK_BASE_URL is not provided
- Added test to document this behavior in test/validate-env.test.ts
- Addresses issues https://github.com/anthropics/claude-code-action/issues/32 and https://github.com/anthropics/claude-code-action/issues/43 where users encountered 404 errors when using Bedrock integration without explicitly setting the base URL

## Background
Users of AWS Bedrock integration were encountering 404 API errors when the ANTHROPIC_BEDROCK_BASE_URL was not explicitly set. 
This change ensures the URL is automatically constructed using the AWS_REGION, making the integration more user-friendly 
and preventing the confusing error messages reported in issues #32 and #43.

## Test Plan
- Added test in test/validate-env.test.ts to document the behavior
- Manual testing with AWS Bedrock integration